### PR TITLE
Make simpleupload-ul always present

### DIFF
--- a/index.php
+++ b/index.php
@@ -356,8 +356,8 @@
 			Maximum upload size: <?php echo $data['max_upload_size']; ?><br />
 			<input type="file" name="file[]" multiple required id="simpleupload-input"/>
 		</form>
-		<?php if ($settings['listfiles']) { ?>
-			<ul id="simpleupload-ul">
+		<ul id="simpleupload-ul">
+			<?php if ($settings['listfiles']) { ?>
 				<?php
 					foreach ($file_array as $mtime => $filename) {
 						$file_info = array();
@@ -403,8 +403,8 @@
 						}
 					}
 				?>
-			</ul>
-		<?php } ?>
+			<?php } ?>
+		</ul>
 		<a href="https://github.com/muchweb/simple-php-upload"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 		<script charset="utf-8">
 			var target_form = document.getElementById('simpleupload-form'),


### PR DESCRIPTION
JS for uploading relies on simpleupload-ul being present to put "Uploading" notification into it.
Not having it (listfiles = false) results in JS error and upload fails.
